### PR TITLE
fix bug: Tween.js start ratio less than 1e-7 will go complete

### DIFF
--- a/src/tween/Tween.js
+++ b/src/tween/Tween.js
@@ -327,20 +327,19 @@ return Class.create(/** @lends Tween.prototype */{
         if(elapsed < 0) return;
 
         //elapsed ratio
-        var ratio = elapsed / me.duration, complete = false, callback;
+        var ratio = elapsed / me.duration, complete = false, completeDuration = elapsed >= me.duraion, callback;
         ratio = ratio <= 0 ? 0 : ratio >= 1 ? 1 : ratio;
         var easeRatio = me.ease ? me.ease(ratio) : ratio;
 
-        if(me.reverse){
-            //backward
-            if(me._reverseFlag < 0) {
-                ratio = 1 - ratio;
-                easeRatio = 1 - easeRatio;
-            }
+        if(me.reverse && me._reverseFlag < 0){
+            ratio = 1 - ratio;
+            easeRatio = 1 - easeRatio;
             //forward
-            if(ratio < 1e-7){
+            if(completeDuration){
                 //repeat complete or not loop
                 if((me.repeat > 0 && me._repeatCount++ >= me.repeat) || (me.repeat == 0 && !me.loop)){
+                    ratio = 0;
+                    easeRatio = 0;
                     complete = true;
                 }else{
                     me._startTime = now();


### PR DESCRIPTION
fix: Tween.js start ratio less than 1e-7 will go complete, optimize logic

test:
![image](https://user-images.githubusercontent.com/1059680/27515363-3306328c-59d4-11e7-9b9a-878091b16a86.png)