### PR TITLE
update http to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,32 +34,32 @@ Built by gulp:
 
 ### API Documentation
 
-Get started by reading [docs/api-en/index.html](http://hiloteam.github.io/Hilo/docs/api-en/index.html)
+Get started by reading [docs/api-en/index.html](https://hiloteam.github.io/Hilo/docs/api-en/index.html)
 
 ### API Samples
 
- * [Index.html](http://hiloteam.github.io/Hilo/examples/index.html)
+ * [Index.html](https://hiloteam.github.io/Hilo/examples/index.html)
  * Visual Objects (View)
-    * [Bitmap](http://hiloteam.github.io/Hilo/examples/Bitmap.html)
-    * [Sprite](http://hiloteam.github.io/Hilo/examples/Sprite.html)
-    * [Graphics](http://hiloteam.github.io/Hilo/examples/Graphics.html)
-    * [DOM element](http://hiloteam.github.io/Hilo/examples/DOMElement.html)
-    * [Button](http://hiloteam.github.io/Hilo/examples/Button.html)
-    * [Background](http://hiloteam.github.io/Hilo/examples/Background.html)
-    * [Canvas Text](http://hiloteam.github.io/Hilo/examples/Text.html)
+    * [Bitmap](https://hiloteam.github.io/Hilo/examples/Bitmap.html)
+    * [Sprite](https://hiloteam.github.io/Hilo/examples/Sprite.html)
+    * [Graphics](https://hiloteam.github.io/Hilo/examples/Graphics.html)
+    * [DOM element](https://hiloteam.github.io/Hilo/examples/DOMElement.html)
+    * [Button](https://hiloteam.github.io/Hilo/examples/Button.html)
+    * [Background](https://hiloteam.github.io/Hilo/examples/Background.html)
+    * [Canvas Text](https://hiloteam.github.io/Hilo/examples/Text.html)
 
  * Others
-    * [Load queue](http://hiloteam.github.io/Hilo/examples/LoadQueue.html)
-    * [Web sound](http://hiloteam.github.io/Hilo/examples/WebSound.html)
-    * [Mouse Event](http://hiloteam.github.io/Hilo/examples/MouseEvent.html)
-    * [Drag](http://hiloteam.github.io/Hilo/examples/drag.html)
+    * [Load queue](https://hiloteam.github.io/Hilo/examples/LoadQueue.html)
+    * [Web sound](https://hiloteam.github.io/Hilo/examples/WebSound.html)
+    * [Mouse Event](https://hiloteam.github.io/Hilo/examples/MouseEvent.html)
+    * [Drag](https://hiloteam.github.io/Hilo/examples/drag.html)
 
  * Extensions
-    * [Camera](http://hiloteam.github.io/Hilo/examples/Camera.html)
-    * [Camera3d](http://hiloteam.github.io/Hilo/examples/Camera3d.html)
-    * [Skeleton Animation - Dragonbones](http://hiloteam.github.io/Hilo/src/extensions/dragonbones/demo/index.html)
-    * [Particle System](http://hiloteam.github.io/Hilo/examples/ParticleSystem.html)
-    * [Physics](http://hiloteam.github.io/Hilo/src/extensions/physics/demo/index.html)
+    * [Camera](https://hiloteam.github.io/Hilo/examples/Camera.html)
+    * [Camera3d](https://hiloteam.github.io/Hilo/examples/Camera3d.html)
+    * [Skeleton Animation - Dragonbones](https://hiloteam.github.io/Hilo/src/extensions/dragonbones/demo/index.html)
+    * [Particle System](https://hiloteam.github.io/Hilo/examples/ParticleSystem.html)
+    * [Physics](https://hiloteam.github.io/Hilo/src/extensions/physics/demo/index.html)
 
 ### Demos
 
@@ -98,4 +98,4 @@ Get started by reading [docs/api-en/index.html](http://hiloteam.github.io/Hilo/d
 [size-url]: https://cdn.rawgit.com/hiloteam/Hilo/master/build/standalone/hilo-standalone.min.js
 
 [example-image]: https://img.alicdn.com/tps/TB1vDlBLVXXXXcDXVXXXXXXXXXX-850-806.png
-[example-url]: http://hiloteam.github.io/examples/index.html
+[example-url]: https://hiloteam.github.io/examples/index.html

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -34,32 +34,32 @@ Hilo 是阿里巴巴集团开发的一款HTML5跨终端游戏解决方案，ta�
 
 ### API 文档
 
-参见 [docs/api-zh/index.html](http://hiloteam.github.io/Hilo/docs/api-zh/index.html)
+参见 [docs/api-zh/index.html](https://hiloteam.github.io/Hilo/docs/api-zh/index.html)
 
 ### API 样例
 
- * [Index.html](http://hiloteam.github.io/Hilo/examples/index.html)
+ * [Index.html](https://hiloteam.github.io/Hilo/examples/index.html)
  * 可视对象 (View)
-    * [Bitmap](http://hiloteam.github.io/Hilo/examples/Bitmap.html)
-    * [Sprite](http://hiloteam.github.io/Hilo/examples/Sprite.html)
-    * [Graphics](http://hiloteam.github.io/Hilo/examples/Graphics.html)
-    * [DOM element](http://hiloteam.github.io/Hilo/examples/DOMElement.html)
-    * [Button](http://hiloteam.github.io/Hilo/examples/Button.html)
-    * [Background](http://hiloteam.github.io/Hilo/examples/Background.html)
-    * [Canvas Text](http://hiloteam.github.io/Hilo/examples/Text.html)
+    * [Bitmap](https://hiloteam.github.io/Hilo/examples/Bitmap.html)
+    * [Sprite](https://hiloteam.github.io/Hilo/examples/Sprite.html)
+    * [Graphics](https://hiloteam.github.io/Hilo/examples/Graphics.html)
+    * [DOM element](https://hiloteam.github.io/Hilo/examples/DOMElement.html)
+    * [Button](https://hiloteam.github.io/Hilo/examples/Button.html)
+    * [Background](https://hiloteam.github.io/Hilo/examples/Background.html)
+    * [Canvas Text](https://hiloteam.github.io/Hilo/examples/Text.html)
 
  * 其他
-    * [Load queue](http://hiloteam.github.io/Hilo/examples/LoadQueue.html)
-    * [Web sound](http://hiloteam.github.io/Hilo/examples/WebSound.html)
-    * [Mouse Event](http://hiloteam.github.io/Hilo/examples/MouseEvent.html)
-    * [Drag](http://hiloteam.github.io/Hilo/examples/drag.html)
+    * [Load queue](https://hiloteam.github.io/Hilo/examples/LoadQueue.html)
+    * [Web sound](https://hiloteam.github.io/Hilo/examples/WebSound.html)
+    * [Mouse Event](https://hiloteam.github.io/Hilo/examples/MouseEvent.html)
+    * [Drag](https://hiloteam.github.io/Hilo/examples/drag.html)
 
  * Hilo扩展 样例
-    * [Camera](http://hiloteam.github.io/Hilo/examples/Camera.html)
-    * [Camera3d](http://hiloteam.github.io/Hilo/examples/Camera3d.html)
-    * [Skeleton Animation - Dragonbones](http://hiloteam.github.io/Hilo/src/extensions/dragonbones/demo/index.html)
-    * [Particle System](http://hiloteam.github.io/Hilo/examples/ParticleSystem.html)
-    * [Physics](http://hiloteam.github.io/Hilo/src/extensions/physics/demo/index.html)
+    * [Camera](https://hiloteam.github.io/Hilo/examples/Camera.html)
+    * [Camera3d](https://hiloteam.github.io/Hilo/examples/Camera3d.html)
+    * [Skeleton Animation - Dragonbones](https://hiloteam.github.io/Hilo/src/extensions/dragonbones/demo/index.html)
+    * [Particle System](https://hiloteam.github.io/Hilo/examples/ParticleSystem.html)
+    * [Physics](https://hiloteam.github.io/Hilo/src/extensions/physics/demo/index.html)
 
 ### Demos
 
@@ -98,4 +98,4 @@ Hilo 是阿里巴巴集团开发的一款HTML5跨终端游戏解决方案，ta�
 [size-url]: https://cdn.rawgit.com/hiloteam/Hilo/master/build/standalone/hilo-standalone.min.js
 
 [example-image]: https://img.alicdn.com/tps/TB1vDlBLVXXXXcDXVXXXXXXXXXX-850-806.png
-[example-url]: http://hiloteam.github.io/examples/index.html
+[example-url]: https://hiloteam.github.io/examples/index.html

--- a/docs/api-en/index.html
+++ b/docs/api-en/index.html
@@ -29,11 +29,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/Bitmap.html
+++ b/docs/api-en/symbols/Bitmap.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/BitmapText.html
+++ b/docs/api-en/symbols/BitmapText.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/Button.html
+++ b/docs/api-en/symbols/Button.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/CacheMixin.html
+++ b/docs/api-en/symbols/CacheMixin.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/Camera.html
+++ b/docs/api-en/symbols/Camera.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/Camera3d.html
+++ b/docs/api-en/symbols/Camera3d.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/CanvasRenderer.html
+++ b/docs/api-en/symbols/CanvasRenderer.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/Class.html
+++ b/docs/api-en/symbols/Class.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/Container.html
+++ b/docs/api-en/symbols/Container.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/DOMElement.html
+++ b/docs/api-en/symbols/DOMElement.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/DOMRenderer.html
+++ b/docs/api-en/symbols/DOMRenderer.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/Drawable.html
+++ b/docs/api-en/symbols/Drawable.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/Ease.html
+++ b/docs/api-en/symbols/Ease.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/EventMixin.html
+++ b/docs/api-en/symbols/EventMixin.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/Graphics.html
+++ b/docs/api-en/symbols/Graphics.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/HTMLAudio.html
+++ b/docs/api-en/symbols/HTMLAudio.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/Hilo.html
+++ b/docs/api-en/symbols/Hilo.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/LoadQueue.html
+++ b/docs/api-en/symbols/LoadQueue.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/Matrix.html
+++ b/docs/api-en/symbols/Matrix.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/ParticleSystem.html
+++ b/docs/api-en/symbols/ParticleSystem.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/Renderer.html
+++ b/docs/api-en/symbols/Renderer.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/Sprite.html
+++ b/docs/api-en/symbols/Sprite.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/Stage.html
+++ b/docs/api-en/symbols/Stage.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/Text.html
+++ b/docs/api-en/symbols/Text.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/TextureAtlas.html
+++ b/docs/api-en/symbols/TextureAtlas.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/Ticker.html
+++ b/docs/api-en/symbols/Ticker.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/Tween.html
+++ b/docs/api-en/symbols/Tween.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/View.html
+++ b/docs/api-en/symbols/View.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/WebAudio.html
+++ b/docs/api-en/symbols/WebAudio.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/WebGLRenderer.html
+++ b/docs/api-en/symbols/WebGLRenderer.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/WebSound.html
+++ b/docs/api-en/symbols/WebSound.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/browser.html
+++ b/docs/api-en/symbols/browser.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/drag.html
+++ b/docs/api-en/symbols/drag.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-en/symbols/util.html
+++ b/docs/api-en/symbols/util.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/index.html
+++ b/docs/api-zh/index.html
@@ -29,11 +29,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/Bitmap.html
+++ b/docs/api-zh/symbols/Bitmap.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/BitmapText.html
+++ b/docs/api-zh/symbols/BitmapText.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/Button.html
+++ b/docs/api-zh/symbols/Button.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/CacheMixin.html
+++ b/docs/api-zh/symbols/CacheMixin.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/Camera.html
+++ b/docs/api-zh/symbols/Camera.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/Camera3d.html
+++ b/docs/api-zh/symbols/Camera3d.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/CanvasRenderer.html
+++ b/docs/api-zh/symbols/CanvasRenderer.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/Class.html
+++ b/docs/api-zh/symbols/Class.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/Container.html
+++ b/docs/api-zh/symbols/Container.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/DOMElement.html
+++ b/docs/api-zh/symbols/DOMElement.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/DOMRenderer.html
+++ b/docs/api-zh/symbols/DOMRenderer.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/Drawable.html
+++ b/docs/api-zh/symbols/Drawable.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/Ease.html
+++ b/docs/api-zh/symbols/Ease.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/EventMixin.html
+++ b/docs/api-zh/symbols/EventMixin.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/Graphics.html
+++ b/docs/api-zh/symbols/Graphics.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/HTMLAudio.html
+++ b/docs/api-zh/symbols/HTMLAudio.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/Hilo.html
+++ b/docs/api-zh/symbols/Hilo.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/LoadQueue.html
+++ b/docs/api-zh/symbols/LoadQueue.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/Matrix.html
+++ b/docs/api-zh/symbols/Matrix.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/ParticleSystem.html
+++ b/docs/api-zh/symbols/ParticleSystem.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/Renderer.html
+++ b/docs/api-zh/symbols/Renderer.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/Sprite.html
+++ b/docs/api-zh/symbols/Sprite.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/Stage.html
+++ b/docs/api-zh/symbols/Stage.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/Text.html
+++ b/docs/api-zh/symbols/Text.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/TextureAtlas.html
+++ b/docs/api-zh/symbols/TextureAtlas.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/Ticker.html
+++ b/docs/api-zh/symbols/Ticker.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/Tween.html
+++ b/docs/api-zh/symbols/Tween.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/View.html
+++ b/docs/api-zh/symbols/View.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/WebAudio.html
+++ b/docs/api-zh/symbols/WebAudio.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/WebGLRenderer.html
+++ b/docs/api-zh/symbols/WebGLRenderer.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/WebSound.html
+++ b/docs/api-zh/symbols/WebSound.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/browser.html
+++ b/docs/api-zh/symbols/browser.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/drag.html
+++ b/docs/api-zh/symbols/drag.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api-zh/symbols/util.html
+++ b/docs/api-zh/symbols/util.html
@@ -35,11 +35,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="../index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/api_template/static/header.html
+++ b/docs/api_template/static/header.html
@@ -15,11 +15,11 @@
 
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li><a href="http://hiloteam.github.io/index.html">首页</a></li>
+        <li><a href="https://hiloteam.github.io/index.html">首页</a></li>
         <li><a href="https://github.com/hiloteam/Hilo" target="_blank">源码下载</a></li>
         <li class="active"><a href="%link.base%index.html">API文档</a></li>
-        <li><a href="http://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
-        <li><a href="http://hiloteam.github.io/examples/index.html">作品演示</a></li>
+        <li><a href="https://hiloteam.github.io/tutorial/index.html">教程文档</a></li>
+        <li><a href="https://hiloteam.github.io/examples/index.html">作品演示</a></li>
       </u>
     </div>
 

--- a/docs/examples/index.html
+++ b/docs/examples/index.html
@@ -1,1 +1,1 @@
-<script>location.replace('http://hiloteam.github.io/examples/index.html')</script>
+<script>location.replace('https://hiloteam.github.io/examples/index.html')</script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,1 +1,1 @@
-<script>location.replace('http://hiloteam.github.io/tutorial/index.html')</script>
+<script>location.replace('https://hiloteam.github.io/tutorial/index.html')</script>

--- a/docs/tutorial/index.html
+++ b/docs/tutorial/index.html
@@ -1,1 +1,1 @@
-<script>location.replace('http://hiloteam.github.io/tutorial/index.html')</script>
+<script>location.replace('https://hiloteam.github.io/tutorial/index.html')</script>

--- a/src/extensions/dragonbones/README.md
+++ b/src/extensions/dragonbones/README.md
@@ -2,8 +2,8 @@
 * This a Hilo version of [DragonBones](http://www.egret.com/products/dragonbones.html).
 
 ## DEMO
-* [demos](http://hiloteam.github.io/Hilo/src/extensions/dragonbones/demo/index.html)
-* [dragon](http://hiloteam.github.io/Hilo/src/extensions/dragonbones/demo/dragon.html)
+* [demos](https://hiloteam.github.io/Hilo/src/extensions/dragonbones/demo/index.html)
+* [dragon](https://hiloteam.github.io/Hilo/src/extensions/dragonbones/demo/dragon.html)
 
 ## Usage
 ```
@@ -43,5 +43,5 @@ ticker.addTick(stage);
 stage.addChild(armature.getDisplay());
 ```
 
-* Check out [dragon demo](http://hiloteam.github.io/Hilo/src/extensions/dragonbones/demo/dragon.html) for a complete example.
+* Check out [dragon demo](https://hiloteam.github.io/Hilo/src/extensions/dragonbones/demo/dragon.html) for a complete example.
 * Check [official tutorial](http://edn.egret.com/cn/docs/page/392) for more info.

--- a/src/extensions/physics/README.md
+++ b/src/extensions/physics/README.md
@@ -2,9 +2,9 @@
 对chipmunk二次封装，简化使用方法
 
 ## example
-* [demo](http://hiloteam.github.io/Hilo/src/extensions/physics/demo/index.html)
-* [joints](http://hiloteam.github.io/Hilo/src/extensions/physics/demo/joints.html)
-* [collision](http://hiloteam.github.io/Hilo/src/extensions/physics/demo/collision.html)
+* [demo](https://hiloteam.github.io/Hilo/src/extensions/physics/demo/index.html)
+* [joints](https://hiloteam.github.io/Hilo/src/extensions/physics/demo/joints.html)
+* [collision](https://hiloteam.github.io/Hilo/src/extensions/physics/demo/collision.html)
 
 ## 使用说明
 


### PR DESCRIPTION
Fix issue: api 文档 404
- 当启用 github pages 时 http 无法重定向，只能用 https [参考这里](https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/)
- topic 中的 url 也请改为 https
